### PR TITLE
Check if directory is a zarr store by checking for existence of .zgroup

### DIFF
--- a/suricat-beams/suricat/beams.py
+++ b/suricat-beams/suricat/beams.py
@@ -14,6 +14,7 @@ from astropy.wcs import WCS
 import astropy.units as u
 from scipy.ndimage import spline_filter, map_coordinates
 import xarray
+from pathlib import Path
 
 from scabha.schema_utils import clickify_parameters
 from .main import cli, schemas
@@ -194,7 +195,7 @@ class BeamWizard(object):
             fitshdr = fits.open(image_name)[0].header
             self.wcs = WCS(fitshdr)
             self.time = None
-        elif image_name.endswith(".zarr") or image_name.endswith(".zarr/"):
+        elif (Path(image_name) / ".zgroup").exists():
             log.info(f"obtaining WCS from dataset {image_name}")
             ds = xarray.open_zarr(image_name)
             fitshdr = fits.Header(dict(ds.attrs['fits_header']))


### PR DESCRIPTION
A zarr store doesn't need to have a .zarr suffix so the check [here](https://github.com/ratt-ru/suricat-beams/blob/16b8e00600c988e7ded6e2a33724a919bce4f8dc/suricat-beams/suricat/beams.py#L197) was a bit flaky. This just uses the recommended way to check if a store is zarr i.e. by checking for the existence of a .zgroup in the directory